### PR TITLE
Bump firebase-admin version to 8.4.0

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -14,7 +14,7 @@
     "deploy": "firebase deploy --only functions"
   },
   "dependencies": {
-    "firebase-admin": "^6.0.0",
+    "firebase-admin": "^8.4.0",
     "firebase-functions": "^2.0.5",
     "dialogflow-fulfillment": "0.5.0",
     "actions-on-google": "2.3.0"


### PR DESCRIPTION
In order to remove the warning:

````
The behavior for Date objects stored in Firestore is going to change
AND YOUR APP MAY BREAK.
To hide this warning and ensure your app does not break, you need to add the
following code to your app before calling any other Cloud Firestore methods:

  const firestore = new Firestore();
  const settings = {/* your settings... */ timestampsInSnapshots: true};
  firestore.settings(settings);
````
which is fixed in the 8.4.x version